### PR TITLE
FIX scstadmin -list_sessions error msg in out cmd

### DIFF
--- a/scstadmin/scstadmin.sysfs/scstadmin
+++ b/scstadmin/scstadmin.sysfs/scstadmin
@@ -3676,7 +3676,7 @@ sub listAttributes {
 
 				next;
 			}
-			$l_value = length($value) if ($l_value < length($value));
+			$l_value = length($value) if (defined($value) && $l_value < length($value));
 		}
 	}
 


### PR DESCRIPTION

In out of "scstadmin -list_sessions" cmd occurs error "Use of uninitialized value in numeric lt (<) at /usr/local/sbin/scstadmin line 3679"